### PR TITLE
Use hidraw instead of libusb on linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ exclude = ["/images/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hidapi = "1.3"
+# On linux, we need to use hidraw over libusb since libusb won't talk to bluetooth devices!
+hidapi = { version = "1.3", features = ["linux-static-hidraw"], default-features = false }
 crossbeam-channel = "0.5"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] , optional = true }


### PR DESCRIPTION
This makes bluetooth devices, and thus joycons, show up!